### PR TITLE
add 'content' parameter to zend_common::license

### DIFF
--- a/manifests/license.pp
+++ b/manifests/license.pp
@@ -10,10 +10,22 @@
 # @param source
 #   Source path or puppet URL to license file
 #
+# @param content
+#   Contents of the license file
+#
 class zend_common::license (
-  String[1] $source,
+  String $content = '',
+  String $source = '',
 ) {
-  file { '/opt/zend/zendphp/etc/license':
-    source => $source,
+  if $content != '' {
+    file { '/opt/zend/zendphp/etc/license':
+      content => $content,
+    }
+  }
+  else {
+    file { '/opt/zend/zendphp/etc/license':
+      source => $source,
+    }
   }
 }
+


### PR DESCRIPTION
The 'content' parameter would be helpful for things like 'vault_lookup'. We commonly use Vault for secrets, certificates and licenses.