### PR TITLE
License File Content

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -26,12 +26,27 @@ class { 'zend_common::license':
   subscribe => Class['zendhq::package'],
 }
 ```
+```puppet
+$license = Deferred('vault_lookup::lookup',["licenses/zendhq"], 'https://vault.server.lcl:8200',)
+class { 'zend_common::license':
+  content    => $license,
+}
+```
 
 #### Parameters
 
 The following parameters are available in the `zend_common::license` class:
 
-* [`source`](#-zend_common--license--source)
+
+* Optional [`content`](#-zend_common--license--content)
+
+##### <a name="-zend_common--license--content"></a>`source`
+
+Data type: `String[10]`
+
+The contents (text) of the license file. If this parameter is specified, the parameter `source` will be ignored.
+
+* Optional [`source`](#-zend_common--license--source)
 
 ##### <a name="-zend_common--license--source"></a>`source`
 

--- a/manifests/license.pp
+++ b/manifests/license.pp
@@ -1,19 +1,40 @@
 # @summary Upload a Zend product license to the proper directory
 #
-# @example
+# @example With license URL
 #   class { 'zend_common::license':
 #     source    => 'puppet:///modules/<MODULE_NAME>/zend/license',
 #     notify    => Class['zendhq::service'],
 #     subscribe => Class['zendhq::package'],
 #   }
 #
+# @example With license text
+#   $license = Deferred('vault_lookup::lookup',["licenses/zendhq"], 'https://vault.server.lcl:8200',)
+#   class { 'zend_common::license':
+#     content    => $license,
+#   }
+#
 # @param source
 #   Source path or puppet URL to license file
 #
+# @param content
+#   Contents of the license file
+#
 class zend_common::license (
-  String[1] $source,
+  Optional[String[10]] $content = undef,
+  Optional[String[1]]  $source  = undef,
 ) {
-  file { '/opt/zend/zendphp/etc/license':
-    source => $source,
+  if $content {
+    file { '/opt/zend/zendphp/etc/license':
+      content => $content,
+    }
+  } elsif $source {
+    file { '/opt/zend/zendphp/etc/license':
+      source => $source,
+    }
+  } else {
+    notify { 'no license':
+      message  => 'Neither "content", nor "source" of the license file have been specified. License file has not been updated.',
+      loglevel => 'warning',
+    }
   }
 }


### PR DESCRIPTION
The 'content' parameter would be helpful for things like 'vault_lookup'. We commonly use Vault for secrets, certificates and licenses.
Second attempt at this PR - should be cleaner this time. Still, it is missing the license_spec.rb update.